### PR TITLE
Fix tests failures on develop (#118)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,14 @@ from __future__ import absolute_import, print_function, unicode_literals
 from app_helper.base_test import BaseTestCase
 
 
+class DummyTokens(list):
+    def __init__(self, *tokens):
+        super(DummyTokens, self).__init__(['dummy_tag'] + list(tokens))
+
+    def split_contents(self):
+        return self
+
+
 class BaseTest(BaseTestCase):
     """
     Base class with utility function

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from copy import copy
 
-from classytags.tests import DummyTokens
 from django.conf import settings
 from django.template.base import Parser
 from django.test import override_settings
@@ -14,7 +13,7 @@ from djangocms_page_meta.forms import TitleMetaAdminForm
 from djangocms_page_meta.templatetags.page_meta_tags import MetaFromPage
 from djangocms_page_meta.utils import get_page_meta, meta_settings
 
-from . import BaseTest
+from . import BaseTest, DummyTokens
 
 
 class PageMetaUtilsTest(BaseTest):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     django111: django-taggit>=0.18,<0.24
     django111: django-polymorphic>=0.9
     django111: django-filer>=1.3
-    django111: djangocms-page-tags>=0.6.2
+    django111: djangocms-page-tags>=0.6.2,<0.8.0
     django111: django-formtools>=2.1,<2.2
     django20: Django>=2.0,<2.1
     django20: django-mptt>=0.8
@@ -30,7 +30,10 @@ deps =
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip
     cms35: https://github.com/divio/django-cms/archive/release/3.5.x.zip
     cms36: https://github.com/divio/django-cms/archive/release/3.6.x.zip
-    cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
+    py27-django111-cms37: django-cms==3.7.1
+    py35-django111-cms37: cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
+    py36-django111-cms37: cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
+    py37-django111-cms37: cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
     -r{toxinidir}/requirements-test.txt
 
 [testenv:pep8]


### PR DESCRIPTION
* Vendorize class from classy-tags tests
* Ping djangocms-page-tags version
* Pin django-cms 3.7.1 on python 2.7 (3.7.2 is broken on python 2.7)